### PR TITLE
Chore: Skip auth instead of fail

### DIFF
--- a/source/.editorconfig
+++ b/source/.editorconfig
@@ -16,7 +16,7 @@ tab_width = 4
 
 # New line preferences
 end_of_line = crlf
-insert_final_newline = false
+insert_final_newline = true
 
 #### .NET Coding Conventions ####
 

--- a/source/src/Slackbot.Net.Endpoints/Middlewares/SlackbotEventAuthMiddleware.cs
+++ b/source/src/Slackbot.Net.Endpoints/Middlewares/SlackbotEventAuthMiddleware.cs
@@ -16,23 +16,23 @@ internal class SlackbotEventAuthMiddleware
 
     public async Task Invoke(HttpContext ctx, ILogger<SlackbotEventAuthMiddleware> logger)
     {
-        bool success = false;
+        AuthenticateResult res;
         try
         {
-            var res = await ctx.AuthenticateAsync(SlackbotEventsAuthenticationConstants.AuthenticationScheme);
-            success = res.Succeeded;
+            res = await ctx.AuthenticateAsync(SlackbotEventsAuthenticationConstants.AuthenticationScheme);
         }
         catch (InvalidOperationException ioe)
         {
             throw new InvalidOperationException("Did you forget to call services.AddAuthentication().AddSlackbotEvents()?", ioe);
         }
 
-        if (success)
+        if (res.Succeeded)
         {
             await _next(ctx);
         }
         else
         {
+            logger.LogWarning($"Unauthorized callback from Slack");
             ctx.Response.StatusCode = StatusCodes.Status401Unauthorized;
             await ctx.Response.WriteAsync("UNAUTHORIZED");
         }


### PR DESCRIPTION
Logs indicated authentication failures instead of just skipping.