### PR TITLE
team_join: add `user.is_bot`

### DIFF
--- a/source/src/Slackbot.Net.Endpoints/Models/Events/TeamJoinEvent.cs
+++ b/source/src/Slackbot.Net.Endpoints/Models/Events/TeamJoinEvent.cs
@@ -10,7 +10,9 @@ public class JoiningUser
     public string Id { get; set; }
     public string Name { get; set; }
     public string Real_Name { get; set; }
-    public JoiningUserProfile? Profile { get; set; }
+    public bool Is_Bot { get; set; }
+    public bool Is_App_User { get; set; }
+    public JoiningUserProfile Profile { get; set; }
 }
 
 public class JoiningUserProfile


### PR DESCRIPTION
Makes it possible to filter out bots/apps.

`team_join` sample:

```diff
{
    "token": "<some-token",
    "team_id": "T1234567",
    "api_app_id": "ABCDEFGH",
    "event": {
        "type": "team_join",
        "user": {
            "id": "U01234567",
            "name": "some_username",
+++         "is_bot": false,
+++         "is_app_user": false,
…
}
```