### PR TITLE
Add interactive block action attributes

### DIFF
--- a/source/src/Slackbot.Net.Endpoints/Models/Interactive/BlockActions/BlockAction.cs
+++ b/source/src/Slackbot.Net.Endpoints/Models/Interactive/BlockActions/BlockAction.cs
@@ -1,3 +1,4 @@
+using Slackbot.Net.Endpoints.Models.Interactive.MessageActions;
 using Slackbot.Net.Models.BlockKit;
 
 namespace Slackbot.Net.Endpoints.Models.Interactive.BlockActions;
@@ -6,6 +7,13 @@ public class BlockActionInteraction : Interaction
 {
     public Team Team { get; set; }
     public User User { get; set; }
-
+    public Channel Channel { get; set; }
+    public Message Message { get; set; }
+    public State State { get; set; }
     public IEnumerable<ActionsBlock> Actions { get; set; }
+}
+
+public class State
+{
+    public Dictionary<string, string> Values { get; set; } = [];
 }


### PR DESCRIPTION
https://api.slack.com/reference/interaction-payloads/block-actions#payload-fields

Trenger en avsjekk på denne - BlockAction skal "egentlig ikke" sende med state... men, 

State sender med state i gitte tilfeller, typ når:

- All blocks are in a single message (not a modal)
- All interactive elements (inputs, selects) are in the same message block structure as the button
- The UI is “self-contained” and Slack is able to serialize all current values at the time of the button click

Som funker i mitt tilfelle. Dette er en udokumentert del av API'et men sjekket over payloads og funker 🤷

Innafor å ta med ?