### PR TITLE
Report MTP test results as GitHub Actions annotations

### DIFF
--- a/build/Program.cs
+++ b/build/Program.cs
@@ -15,7 +15,7 @@ Target(Restore, () => RunAsync("dotnet", $"restore {solution}"));
 
 Target(Build, new[] { Restore }, () => RunAsync("dotnet", $"build {solution} --no-restore"));
 
-Target(Test, new[] { Build }, () => RunAsync("dotnet", $"test {solution} --no-build"));
+Target(Test, new[] { Build }, () => RunAsync("dotnet", $"test {solution} --no-build -- --report-gh"));
 
 Target(Pack, new[] { Build }, async () =>
 {

--- a/source/test/Slackbot.Net.SlackClients.Http.Tests/Slackbot.Net.SlackClients.Http.Tests.csproj
+++ b/source/test/Slackbot.Net.SlackClients.Http.Tests/Slackbot.Net.SlackClients.Http.Tests.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.10.0"/>
     <PackageReference Include="xunit.v3" Version="4.0.0"/>
     <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0"/>
+    <PackageReference Include="Microsoft.Testing.Extensions.GitHubActionsReport" Version="2.4.0"/>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- CI on `main` has failed twice in a row on real Slack API integration tests timing out (`ChatGetPermalinkTests`, then `AddReactionTests`) but the raw `dotnet test` console log makes the failing test hard to spot.
- Adds `Microsoft.Testing.Extensions.GitHubActionsReport` to the test project and passes `--report-gh` through the Bullseye `test` target.
- Microsoft.Testing.Platform now writes a per-assembly pass/fail summary (with collapsible failure details: exception, location, stack trace) straight to the GitHub Actions job summary.
- Only activates when `GITHUB_ACTIONS=true`; local `dotnet run --project build -- test` runs are unaffected.

## Test plan
- [x] Verified locally with `GITHUB_ACTIONS=true GITHUB_STEP_SUMMARY=<file> dotnet test source --no-build -- --report-gh` — produces a clean per-TFM Markdown summary with collapsible failure details.
- [x] Verified the flag is inert without `GITHUB_ACTIONS` set (plain console output as before).
- [ ] CI run on this PR shows the new job summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)